### PR TITLE
Update Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,12 +96,12 @@ module.exports = function(grunt) {
         sass: {
             // `grunt sass:dev`
             dev: {
-                options: { style: "normal", sourcemap: true },
+                options: { style: "normal", sourceMap: true },
                 files: sass_files,
             },
             // `grunt sass:prod`
             prod: {
-                options: { style: "compressed", sourcemap: true },
+                options: { style: "compressed", sourceMap: true },
                 files: sass_files,
             }
 


### PR DESCRIPTION
Source mapping was not working when I switched to SASS in C. Looks like they changed the property name.

Here's the article where i found the change. 
http://benfrain.com/lightning-fast-sass-compiling-with-libsass-node-sass-and-grunt-sass/
