### PR TITLE
Add Option For All Layouts

### DIFF
--- a/css/sass/supporting/layout.scss
+++ b/css/sass/supporting/layout.scss
@@ -1,13 +1,96 @@
 /*
 Layout Styling */
 
-body.sidebar-content {
-    .content-sidebar-wrap {
-        main {
-            float: right;
-            @media (max-width: 767px) {
-              float: none;
-            }
-        }
-    }
+.site-inner{
+  @include .container-fixed();
+  @media (min-width: $screen-sm-min) {
+    width: $container-sm;
+  }
+  @media (min-width: $screen-md-min) {
+    width: $container-md;
+  }
+  @media (min-width: $screen-lg-min) {
+    width: $container-lg;
+  }
+}
+.content-sidebar-wrap {
+  @include make-row;
+}
+
+.content-sidebar .content,
+.sidebar-content .content {
+  @include .make-xs-column(12);
+  @include .make-sm-column(8);
+  @include .make-md-column(8);
+  @include .make-lg-column(9);
+}
+.content-sidebar .sidebar-primary,
+.sidebar-content .sidebar-primary {
+  @include .make-xs-column(12);
+  @include .make-sm-column(4);
+  @include .make-md-column(4);
+  @include .make-lg-column(3);
+}
+ 
+.sidebar-content .content  {
+  @include .make-sm-column-push(4);
+  @include .make-md-column-push(4);
+}
+ 
+.sidebar-content .sidebar-primary  {
+  @include .make-sm-column-pull(8);
+  @include .make-md-column-pull(8);
+}
+ 
+.sidebar-content-sidebar .content,
+.content-sidebar-sidebar .content {
+  @include .make-xs-column(12);
+  @include .make-sm-column(6);
+  @include .make-md-column(6);
+  @include .make-lg-column(6);
+}
+ 
+.sidebar-content-sidebar .sidebar-primary,
+.sidebar-content-sidebar .sidebar-secondary,
+.content-sidebar-sidebar .sidebar-primary, 
+.content-sidebar-sidebar .sidebar-secondary  {
+  @include .make-xs-column(12);
+  @include .make-sm-column(3);
+  @include .make-md-column(3);
+  @include .make-lg-column(3);
+}
+ 
+.sidebar-sidebar-content .content  {
+  @include .make-xs-column(12);
+  @include .make-sm-column(6);
+  @include .make-md-column(6);
+  @include .make-lg-column(6);
+}
+.sidebar-sidebar-content .sidebar-primary, 
+.sidebar-sidebar-content .sidebar-secondary  {
+  @include .make-xs-column(12);
+  @include .make-sm-column(3);
+  @include .make-md-column(3);
+  @include .make-lg-column(3);
+}
+.sidebar-sidebar-content .content  {
+  @include .make-sm-column-push(6);
+  @include .make-md-column-push(6);
+}
+.sidebar-sidebar-content .sidebar-primary  {
+  @include .make-sm-column-pull(6);
+  @include .make-md-column-pull(6);
+}
+.sidebar-sidebar-content .sidebar-secondary {
+  @include .make-sm-column-pull(6);
+  @include .make-md-column-pull(6);
+}
+ 
+.sidebar-content-sidebar .content  {
+  @include .make-sm-column-push(3);
+  @include .make-md-column-push(3);
+}
+.sidebar-content-sidebar .sidebar-primary  {
+  @include .make-sm-column-pull(6);
+  @include .make-md-column-pull(6);
 }


### PR DESCRIPTION
This is my first time using sass/scss and less. I tested with less and it works. It could probably be shortened and optimized for different media queries. Here is the less version that works for sure. https://gist.github.com/bryanwillis/08b64ac92a2bf714417b#file-genesis-bootstrap-layouts-less. For this to work genesis_after_content_sidebar_wrap() has to be moved inside content_sidebar_wrap. See page.php in root directory or https://gist.github.com/bryanwillis/08b64ac92a2bf714417b#file-bootstrap-genesis-template-php. I tried various other methods like filtering the classes or adding/rearranging hooks as well as  genesis_site_layout(), but after unnecessary hassle messing with the php, css seemed like the simplest approach. It can be seen live here http://runningblog.wpengine.com/content-sidebar/ by clicking the layout submenus under main nav.