### PR TITLE
Fix missing classes from navbar

### DIFF
--- a/lib/bootstrap-markup.php
+++ b/lib/bootstrap-markup.php
@@ -16,8 +16,8 @@ function bsg_add_markup_class( $attr, $context ) {
     $classes_to_add = apply_filters ('bsg-classes-to-add',
         // default bootstrap markup values
         array(
-            'nav-primary'               => 'navbar navbar-default',
-            'nav-secondary'             => 'navbar navbar-inverse',
+            'nav-primary'               => 'navbar navbar-default navbar-static-top',
+            'nav-secondary'             => 'navbar navbar-inverse navbar-static-top',
             'site-header'               => 'container',
             'site-inner'                => 'container',
             'site-footer'               => 'container',

--- a/lib/bootstrap-markup.php
+++ b/lib/bootstrap-markup.php
@@ -1,6 +1,8 @@
 <?php
 
 // add bootstrap classes
+add_filter( 'genesis_attr_nav-primary',         'bsg_add_markup_class', 10, 2 );
+add_filter( 'genesis_attr_nav-secondary',       'bsg_add_markup_class', 10, 2 );
 add_filter( 'genesis_attr_site-header',         'bsg_add_markup_class', 10, 2 );
 add_filter( 'genesis_attr_site-inner',          'bsg_add_markup_class', 10, 2 );
 add_filter( 'genesis_attr_content-sidebar-wrap','bsg_add_markup_class', 10, 2 );
@@ -14,13 +16,15 @@ function bsg_add_markup_class( $attr, $context ) {
     $classes_to_add = apply_filters ('bsg-classes-to-add',
         // default bootstrap markup values
         array(
-            'site-header'       => 'container',
-            'site-inner'        => 'container',
-            'site-footer'       => 'container',
+            'nav-primary'               => 'navbar navbar-default',
+            'nav-secondary'             => 'navbar navbar-inverse',
+            'site-header'               => 'container',
+            'site-inner'                => 'container',
+            'site-footer'               => 'container',
             'content-sidebar-wrap'      => 'row',
-            'content'           => 'col-sm-9',
-            'sidebar-primary'   => 'col-sm-3',
-            'archive-pagination'=> 'clearfix',
+            'content'                   => 'col-sm-9',
+            'sidebar-primary'           => 'col-sm-3',
+            'archive-pagination'        => 'clearfix',
         ),
         $context,
         $attr


### PR DESCRIPTION
This goes along with other changes to remove redundant nested nav elements. Still don't think I'm doing the PR's right. This belongs with this https://github.com/bryanwillis/bootstrap-genesis/commit/9b7307a3006384dfb7834f7d5cdbdb1050837f6f but I don't know if there is a way to show them together.