### PR TITLE
Fix Primary nav margins when both menus enabled

### DIFF
--- a/lib/nav.php
+++ b/lib/nav.php
@@ -74,3 +74,22 @@ EOT;
     $output .= '</div>'; // .container-fluid
     return $output;
 }
+
+
+function bsg_remove_primary_bottom_margin() {
+?>
+  <style type="text/css">
+  nav.nav-primary.navbar.navbar-default.navbar-static-top {
+      margin-bottom: 0px!important;
+  }
+  </style>
+<?php
+}
+
+
+function bsg_has_nav_menu_primary_secondary_check() {
+  if ( has_nav_menu( 'primary' ) && has_nav_menu( 'secondary' ) ) {
+        add_action('wp_head', 'bsg_remove_primary_bottom_margin');
+  }
+}
+add_action('get_header', 'bsg_has_nav_menu_primary_secondary_check');


### PR DESCRIPTION
When both primary and secondary menus are enabled, there is a 20px gap between the two menus. Bootstrap adds a margin to the bottom of the menu to create spacing between the menu and the page content, but when two menus are stacked this creates unnecessary gap between the two menus. This seems like a lot of code to add to change just one css rule, there is probably a smarter way to do this that I'm not thinking of.