### PR TITLE
Add X-UA-Compatible and viewport

### DIFF
--- a/lib/ie-conditional-comments.php
+++ b/lib/ie-conditional-comments.php
@@ -18,6 +18,8 @@ function bsg_conditional_comments() {
  // http://www.paulirish.com/2008/conditional-stylesheets-vs-css-hacks-answer-neither/
  */ ?>
 <head profile="http://gmpg.org/xfn/11">
-<meta charset="UTF-8" />
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
    <?php
 }


### PR DESCRIPTION
 Add X-UA-Compatible and viewport here to comply with bootstraps changes:
https://github.com/twbs/bootstrap/issues/15601

This would also allow removal of two additional files:
ie-conditional-comments.php
responsive-viewport.php

Basically unless these meta tags immediately follow the head tag (specifically x-ua-compatible), the site will break in IE-8 when compatibility mode is on. I just realized this was added to core bootstrap a few months ago. I originally came across this last year with a friend who was using Squarespace and IE-8 (which didn't have support for this at the time). This article is old but does a good job of explaining, if you're interested (http://www.validatethis.co.uk/news/fix-bad-value-x-ua-compatible-once-and-for-all/) Anyway, I think this is pretty important to add. Thoughts?
