### PR TITLE
Fix genesis_markup()

### DIFF
--- a/lib/pagination-prev-next.php
+++ b/lib/pagination-prev-next.php
@@ -50,7 +50,7 @@ function bsg_genesis_prev_next_posts_nav() {
 
 	$nav .= $prev;
 	$nav .= $next;
-	$nav .= '</ul></nav>';
+	$nav .= genesis_html5() ? '</ul></nav>' : '</ul></div>';
 
 	if ( $prev || $next )
 		echo $nav;


### PR DESCRIPTION
Missing markup for closing tag when rendering xhtml:

``` php
genesis_html5() ? '</ul></nav>' : '</ul></div>'
```

Optionally it can be done like this as well, but the above seems to be the standard method by genesis now,

``` php
genesis_markup( array(
    'html5'   => '</ul></nav>',
    'xhtml'   => '</ul></div>',
 ) )
```
