### PR TITLE
Support for Genesis Accessibility

### DIFF
--- a/css/sass/supporting/screen-reader-text.scss
+++ b/css/sass/supporting/screen-reader-text.scss
@@ -1,0 +1,14 @@
+/* Genesis accessibility support for screen readers
+------------------------------------------------------------ */
+
+.screen-reader-text,
+.screen-reader-text span {
+  @extend .sr-only;
+}
+
+.screen-reader-text {
+  &:active,
+  &:focus {
+    @extend .sr-only-focusable;
+  }
+}


### PR DESCRIPTION
Unfortunately Genesis doesn't use `genesis_attr()` for the accessibility classes so we can't add the classes with php. This allows themes to add `genesis-accessibility` theme support using Bootstrap's classes... I don't use sass ever, but I think this is right.
