### PR TITLE
Add support for new editor CSS image classes

### DIFF
--- a/css/sass/supporting/wordpress-image.scss
+++ b/css/sass/supporting/wordpress-image.scss
@@ -44,6 +44,28 @@
     img.alignnone {
         margin: 5px 0;
     }
+
+    .alignwide,
+    .alignfull {
+        margin-left: calc(25% - 25vw);
+        margin-right: calc(25% - 25vw);
+        width: auto;
+        max-width: 1000%;
+    }
+
+    /**
+     * Only apply alignfull on full width content page template.
+     */
+    .full-width-content .alignfull {
+        margin-left: calc(50% - 50vw);
+        margin-right: calc(50% - 50vw);
+    }
+
+    .alignwide img,
+    .alignfull img {
+        display: block;
+        margin: 0 auto;
+    }
 }
 
 .wp-caption .wp-caption-text,

--- a/lib/block-editor-support.php
+++ b/lib/block-editor-support.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @see https://wordpress.org/gutenberg/handbook/extensibility/theme-support/#wide-alignment
+ */
+add_theme_support( 'align-wide' );


### PR DESCRIPTION
This is a first pass at adding the new (Gutenberg) block-based editor CSS image classes.

See #182 
